### PR TITLE
1003, 2839, 11399

### DIFF
--- a/신경호/1003.py
+++ b/신경호/1003.py
@@ -1,0 +1,24 @@
+import sys
+input = sys.stdin.readline
+
+def fi(n,lt):
+    if lt[n] != [-1,-1]:
+        return lt[n]
+    
+    fi0 = fi(n-1,lt)
+    fi1 = fi(n-2,lt)
+    lt[n] = [fi0[0] + fi1[0],fi0[1]+fi1[1]]
+    
+    return lt[n]
+
+num = int(input())
+for _ in range(num):
+    tem = int(input())
+    lt = [[-1,-1] for _ in range(tem+2)]
+    lt[0] = [1,0]
+    lt[1] = [0,1]
+    result = fi(tem,lt)
+    print(result[0],result[1])
+    
+    
+

--- a/신경호/11399.py
+++ b/신경호/11399.py
@@ -1,0 +1,19 @@
+# 앞에 존재하는 사람이 걸린 시간이 중복하여서 계산됨
+# 시간에 따른 오름차순으로 정렬하여 더하면 해결할 것으로 보임
+import sys
+
+input = sys.stdin.readline
+
+num = int(input())
+lt = list(map(int,input().split()))
+
+sort_lt = sorted(lt,key = lambda x : x)
+
+time_list = [0 for i in range(num)]
+for i in range(num):
+    if i == 0:
+        time_list[i] = sort_lt[i]
+    else:
+        time_list[i] = time_list[i-1] + sort_lt[i]
+#메모리제이션을 이용하여 한 사람당 걸린 시간을 계산
+print(sum(time_list))

--- a/신경호/2839.py
+++ b/신경호/2839.py
@@ -1,0 +1,22 @@
+import sys
+
+input = sys.stdin.readline
+
+num = int(input())
+
+m = num // 5
+cnt = 10000
+for i in range(m,-1,-1):
+    now = num - 5*i
+    if now % 3 != 0:
+        continue
+    now_3 = now // 3
+    total = i + now_3
+    if total <= cnt:
+        cnt = total
+if cnt == 10000:
+    print(-1)
+else:    
+    print(cnt)
+    
+    


### PR DESCRIPTION
# 🧩 코딩테스트 문제 풀이

## 📝 문제 정보
- 문제 이름: 피보나치 함수
- 문제 링크: https://www.acmicpc.net/problem/1003
- 난이도: 실버3
- 알고리즘 유형: DP

## 💡 접근 방법
- 처음에는 기본 재귀함수를 이용하여 풀이 -> 제한시간에 걸림
- 기존의 계산 결과를 저장하는 리스트를 정의
- 문제 풀이에는 0과 1이 호출된 수만 필요하여 2차원 배열로 선언

## ⏱️ 시간복잡도
- O(n)
- fi 함수가 한번만 동작되며 n, 기존의 계산값을 사용하기 때문에 함수 내에서 계산되는 시간은 O(1)
## 🗃️ 공간복잡도
- O(n)
- lt가 n+2의 크기이기 때문
- 
## 🧐 배운 점 & 어려웠던 점
- 시간복잡도를 고려하여 DP를 사용해야 한다는 것을 학습

## 📝 문제 정보
- 문제 이름: 설탕배탈
- 문제 링크: https://www.acmicpc.net/problem/2839
- 난이도: 실버4
- 알고리즘 유형: 그리디

## 💡 접근 방법
- 문제에서 제시하는 n은 3<n<5000
- 위 조건을 기반으로 n의 초기 값은 10000으로 선언
- n을 5로 나눈 몫에서 0까지 반복문을 통하여 남은 소금의 양을 3으로 나누어서 값을 계산


## ⏱️ 시간복잡도
- O(n)
- for문이 n//5만큼 반복되며 안의 내용은 단순한 나머지 계산이기에 O(1)
## 🗃️ 공간복잡도
- O(1)
- 리스트가 없이 단순히 변수만 존재
## 🧐 배운 점 & 어려웠던 점
- 그리디 알고리즘의 개념을 알 수 있었음

## 📝 문제 정보
- 문제 이름: ATM
- 문제 링크: https://www.acmicpc.net/problem/11399
- 난이도: 실버4
- 알고리즘 유형: 그리디, 정렬

## 💡 접근 방법
- 대기 시간은 자신이 걸리는 시간 + 앞에 사람들의 시간
- 오름차순으로 정렬하면 대기 시간이 최소화 될 것이라 생각

## ⏱️ 시간복잡도
- O(nlogn)
- sorted 연산에 O(nlogn) + 누적 합 계산 O(n)
## 🗃️ 공간복잡도
- O(n)
- 사용된 리스트 lt, sort_lt, tiem_sort가 전부  O(n)
## 🧐 배운 점 & 어려웠던 점
- 최적화가 덜 된 것 같아서 다른 방법도 찾아볼 것임
